### PR TITLE
Add ability the ability to specify a custom commit signature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ There are a few flags and configuration options which allow you to specify the r
 * `-b --branch` - Branch within the remote that this command should deploy to.
 * `-m --message` - Message that will be applied to the deployment commit.
 * `-f --folder` - Folder within the remote repository in which the project should build. (For instance, this should be `docroot` when deploying to an Acquia repository).
+* `-n --name` - Name to use for the deployment commit signature. If name is specified, email is also required.
+* `-e --email` - Email to use for the deployment commit signature. If email is specified, name is also required.
 
 All of these options can be set within `aquifer.json` so you do not have to specify the flags/values every time you would like to run `deploy-git`. To learn more about setting these options, read the [Configuration](#configuration) section of this document.
 
@@ -36,7 +38,9 @@ _in your `aquifer.json` file:_
     "source": "aquifer-git",
     "remote": "user@agitrepositoryhost.com:repositoryname.git",
     "branch": "master",
-    "folder": "docroot"
+    "folder": "docroot",
+    "name": "Deploy Bot",
+    "email": "deploybot@aquifer.io"
   }
 }
 ...

--- a/bin/index.js
+++ b/bin/index.js
@@ -189,7 +189,7 @@ module.exports = function(Aquifer, AquiferGitConfig) {
         return new Promise(function (resolve, reject) {
           build.create(make, false, path.join(Aquifer.projectDir, Aquifer.project.config.paths.make), false, function (error) {
             if (error) {
-              reject();
+              reject(error);
             }
             else {
               resolve();

--- a/bin/index.js
+++ b/bin/index.js
@@ -42,6 +42,16 @@ module.exports = function(Aquifer, AquiferGitConfig) {
             name: '-f, --folder <folder_name>',
             default: false,
             description: 'Subfolder in remote repository that should hold the build.'
+          },
+          name: {
+            name: '-n, --name <name>',
+            default: false,
+            description: 'Name to use for the deployment commit signature.'
+          },
+          email: {
+            name: '-e, --email <email>',
+            default: false,
+            description: 'Email to use for the deployment commit signature.'
           }
         }
       }
@@ -83,6 +93,12 @@ module.exports = function(Aquifer, AquiferGitConfig) {
     });
 
     if (optionsMissing) {
+      return false;
+    }
+
+    // Validate custom signature options.
+    if (!options.name != !options.email) {
+      callback('Both name and email options are required for a custom commit signature.');
       return false;
     }
 
@@ -213,8 +229,18 @@ module.exports = function(Aquifer, AquiferGitConfig) {
 
       // Commit changes.
       .then(function () {
+        var signature;
+
         Aquifer.console.log('Commit changes...', 'status');
-        var signature = git.Signature['default'](repo);
+
+        if (options.name && options.email) {
+          // Use custom signature.
+          signature = git.Signature.now(options.name, options.email);
+        }
+        else {
+          // Use default signature.
+          signature = git.Signature['default'](repo);
+        }
 
         return repo.createCommitOnHead(['.'], signature, signature, options.message);
       })

--- a/bin/index.js
+++ b/bin/index.js
@@ -96,8 +96,9 @@ module.exports = function(Aquifer, AquiferGitConfig) {
       return false;
     }
 
-    // Validate custom signature options.
-    if (!options.name != !options.email) {
+    // If we have a name without an email, or an email with no name (like XOR),
+    // then we cannot create a custom signature and need to bail out.
+    if (!options.name !== !options.email) {
       callback('Both name and email options are required for a custom commit signature.');
       return false;
     }

--- a/bin/index.js
+++ b/bin/index.js
@@ -63,7 +63,7 @@ module.exports = function(Aquifer, AquiferGitConfig) {
    * @param {string} command string representing the name of the command defined in AquiferGit.commands that should run.
    * @param {object} commandOptions options passed from the command.
    * @param {function} callback function that is called when there is an error message to send.
-   * @returns {boolean|object} false if the deploy fails, git clone object if it succeeds.
+   * @returns {undefined} null.
    */
   AquiferGit.run = function (command, commandOptions, callback) {
     if (command !== 'deploy-git') {
@@ -84,7 +84,6 @@ module.exports = function(Aquifer, AquiferGitConfig) {
       return nextValue ? nextValue : lastValue;
     });
 
-
     requiredOptions.forEach(function (name) {
       if (!options[name]) {
         callback('"' + name + '" option is missing. Cannot deploy.');
@@ -93,14 +92,14 @@ module.exports = function(Aquifer, AquiferGitConfig) {
     });
 
     if (optionsMissing) {
-      return false;
+      return;
     }
 
     // If we have a name without an email, or an email with no name (like XOR),
     // then we cannot create a custom signature and need to bail out.
     if (!options.name !== !options.email) {
       callback('Both name and email options are required for a custom commit signature.');
-      return false;
+      return;
     }
 
     // Create the destination directory and initiate the promise chain.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aquifer-git",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Git deployment for Aquifer.",
   "main": "./bin/index.js",
   "scripts": {


### PR DESCRIPTION
This PR adds the `-n --name` and `-e --email` options to allow the specification of custom deployment commit signatures.
## To Review:
- [ ] Read through the updated README.md and see that the documentation is intuitive.
- [ ] Run a deployment only specifying a name. See you receive an error message that both email and name are required.
- [ ] Run a deployment specifying both email and name options and see the deployment is successful.
