### PR TITLE
Added remove sync to prevent symlink problems with copysync.

### DIFF
--- a/aquifer-git.js
+++ b/aquifer-git.js
@@ -202,6 +202,7 @@ module.exports = (Aquifer, AquiferGitConfig) => {
         options.deploymentFiles.forEach(function (link) {
           let src = path.join(Aquifer.projectDir, link.src);
           let dest = path.join(destPath, link.dest);
+          fs.removeSync(dest);
           fs.copySync(src, dest, {clobber: true});
         });
       })


### PR DESCRIPTION
Summarized in #21 

There can be symlink problems that prevent copySync from succeeding if you are using it to push deployment files into your build. I found this out through trying to force a properly built vendor file (see need for post build activity in #21).

For the moment - this commit - removing the dir or file you intend to sync to before you actually do the sync prevents this issue and I don't think interferes with the original functionality as intended. Unless that intention was some kind of merge (which based on the examples I do not think it was).

If the merge capability was desired or desireable -- we could add an option to control this behavior - I just wanted to keep it light weight since you were deprecating this feature. However, unless we take much more drastic action there is no current way to deal with the symlink problem.
